### PR TITLE
Added pcap microseconds field to packet and added logic to use UDP packet length

### DIFF
--- a/hadoop-pcap-lib/src/main/java/net/ripe/hadoop/pcap/packet/Packet.java
+++ b/hadoop-pcap-lib/src/main/java/net/ripe/hadoop/pcap/packet/Packet.java
@@ -7,6 +7,7 @@ public class Packet extends HashMap<String, Object> {
 	private static final long serialVersionUID = 8723206921174160146L;
 
 	public static final String TIMESTAMP = "ts";
+	public static final String TIMESTAMP_MICROS = "tsmicros";
 	public static final String TTL = "ttl";
 	public static final String PROTOCOL = "protocol";
 	public static final String SRC = "src";
@@ -15,6 +16,7 @@ public class Packet extends HashMap<String, Object> {
 	public static final String DST_PORT = "dst_port";
 	public static final String LEN = "len";
 	public static final String UDPSUM = "udpsum";
+	public static final String UDP_LENGTH = "udp_length";
 	public static final String TCP_FLAG_NS = "tcp_flag_ns";
 	public static final String TCP_FLAG_CWR = "tcp_flag_cwr";
 	public static final String TCP_FLAG_ECE = "tcp_flag_ece";

--- a/hadoop-pcap-lib/src/test/java/net/ripe/hadoop/pcap/PcapReaderTest.java
+++ b/hadoop-pcap-lib/src/test/java/net/ripe/hadoop/pcap/PcapReaderTest.java
@@ -27,13 +27,14 @@ public class PcapReaderTest {
 
 	@Test
 	public void readPayload() {
-		byte[] payload = reader.readPayload(new String("foo bar").getBytes(), 4);
+		byte[] stringBytes = new String("foo bar").getBytes();
+		byte[] payload = reader.readPayload(stringBytes, 4, stringBytes.length-4);
 		assertEquals("bar", new String(payload));
 	}
 
 	@Test
 	public void readPayloadBrokenOffset() {
-		byte[] payload = reader.readPayload(new byte[1], 2);
+		byte[] payload = reader.readPayload(new byte[1], 2, 1);
 		assertTrue(0 == payload.length);
 	}
 


### PR DESCRIPTION
- Added pcap timestamp microseconds field "tmicros" to complement the
  current timestamp in seconds field "ts"
- Added logic to read the packet length field in UDP packets and use it
  as a primary reference to extract payload. Before this patch, the code
  assumed that the payload is the remainder of the packet after the
  headers. However that is not the case when pcap packets are padded.
