### PR TITLE
New field ts_usec, timestamp with microseconds in one field

### DIFF
--- a/hadoop-pcap-lib/src/main/java/net/ripe/hadoop/pcap/packet/Packet.java
+++ b/hadoop-pcap-lib/src/main/java/net/ripe/hadoop/pcap/packet/Packet.java
@@ -8,6 +8,7 @@ public class Packet extends HashMap<String, Object> {
 
 	public static final String TIMESTAMP = "ts";
 	public static final String TIMESTAMP_MICROS = "tsmicros";
+    public static final String TS_USEC = "ts_usec";
 	public static final String TTL = "ttl";
 	public static final String IP_VERSION = "ip_version";	
 	public static final String PROTOCOL = "protocol";

--- a/hadoop-pcap-serde/README.md
+++ b/hadoop-pcap-serde/README.md
@@ -23,6 +23,7 @@ You can use the following parameters to combine multiple input files into splits
 	SET net.ripe.hadoop.pcap.io.reader.class=net.ripe.hadoop.pcap.DnsPcapReader;
 
 	CREATE EXTERNAL TABLE pcaps (ts bigint,
+	                             ts_usec decimal,
 	                             protocol string,
 	                             src string,
 	                             src_port int,
@@ -35,7 +36,7 @@ You can use the following parameters to combine multiple input files into splits
 	                             dns_opcode string,
 	                             dns_rcode string,
 	                             dns_question string,
-	       	                     dns_answer array<string>,
+	                             dns_answer array<string>,
 	                             dns_authority array<string>,
 	                             dns_additional array<string>)
 	ROW FORMAT SERDE 'net.ripe.hadoop.pcap.serde.PcapDeserializer'


### PR DESCRIPTION
Patch to add a field called "ts_usec", that contains the timestamp with
microseconds. Useful for calculating precisely time elapsed between
query and response, or between queries from the same source.
