### PR TITLE
Fix for 'java.lang.Boolean cannot be cast to java.lang.Integer' error

### DIFF
--- a/hadoop-pcap-lib/src/main/java/net/ripe/hadoop/pcap/DnsPcapReader.java
+++ b/hadoop-pcap-lib/src/main/java/net/ripe/hadoop/pcap/DnsPcapReader.java
@@ -62,7 +62,7 @@ public class DnsPcapReader extends PcapReader {
 				Header header = msg.getHeader();
 				dnsPacket.put(DnsPacket.QUERYID, header.getID());
 				dnsPacket.put(DnsPacket.FLAGS, header.printFlags());
-				dnsPacket.put(DnsPacket.QR, header.getFlag(Flags.QR));
+				dnsPacket.put(DnsPacket.QR, header.getFlag(Flags.QR) ? 1 : 0);
 				dnsPacket.put(DnsPacket.OPCODE, Opcode.string(header.getOpcode()));
 				dnsPacket.put(DnsPacket.RCODE, Rcode.string(header.getRcode()));
 				dnsPacket.put(DnsPacket.QUESTION, convertRecordToString(msg.getQuestion()));


### PR DESCRIPTION
when parsing the dns_qr field.

hive> SELECT dns_qr from pcaps limit 10;          
OK
Failed with exception java.io.IOException:org.apache.hadoop.hive.ql.metadata.HiveException: java.lang.ClassCastException: java.lang.Boolean cannot be cast to java.lang.Integer
Time taken: 2.362 seconds
