### PR TITLE
replacing old API classes

### DIFF
--- a/hadoop-pcap-lib/src/main/java/net/ripe/hadoop/pcap/io/PcapInputFormat.java
+++ b/hadoop-pcap-lib/src/main/java/net/ripe/hadoop/pcap/io/PcapInputFormat.java
@@ -17,60 +17,50 @@ import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.ObjectWritable;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.io.compress.CompressionCodecFactory;
-import org.apache.hadoop.mapred.FileInputFormat;
-import org.apache.hadoop.mapred.FileSplit;
-import org.apache.hadoop.mapred.InputSplit;
-import org.apache.hadoop.mapred.JobConf;
-import org.apache.hadoop.mapred.RecordReader;
-import org.apache.hadoop.mapred.Reporter;
+import org.apache.hadoop.mapreduce.lib.input.FileSplit;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
 
-public class PcapInputFormat extends FileInputFormat<LongWritable, ObjectWritable> {
-	static final String READER_CLASS_PROPERTY = "net.ripe.hadoop.pcap.io.reader.class";
+public class PcapInputFormat extends org.apache.hadoop.mapreduce.lib.input.FileInputFormat<LongWritable, ObjectWritable> {
+    static final String READER_CLASS_PROPERTY = "net.ripe.hadoop.pcap.io.reader.class";
 
-	public static final Log LOG = LogFactory.getLog(PcapInputFormat.class);
+    public static final Log LOG = LogFactory.getLog(PcapInputFormat.class);
 
-	@Override
-	public RecordReader<LongWritable, ObjectWritable> getRecordReader(InputSplit split, JobConf config, Reporter reporter) throws IOException {
-		FileSplit fileSplit = (FileSplit)split;
-		Path path = fileSplit.getPath();
-		LOG.info("Reading PCAP: " + path.toString());
-		long start = 0L;
-		long length = fileSplit.getLength();
-		return initPcapRecordReader(path, start, length, reporter, config);
-	}
+    public org.apache.hadoop.mapreduce.RecordReader<LongWritable, ObjectWritable> createRecordReader(org.apache.hadoop.mapreduce.InputSplit split, TaskAttemptContext context) throws IOException, InterruptedException {
+        FileSplit fileSplit = (FileSplit)split;
+        Path path = fileSplit.getPath();
+        LOG.info("Reading PCAP: " + path.toString());
+        long start = 0L;
+        long length = fileSplit.getLength();
+        return initPcapRecordReader(path, start, length, context);
+    }
 
-	public static PcapRecordReader initPcapRecordReader(Path path, long start, long length, Reporter reporter, Configuration conf) throws IOException {
-	    FileSystem fs = path.getFileSystem(conf);
-	    FSDataInputStream baseStream = fs.open(path);
-	    DataInputStream stream = baseStream;
-		CompressionCodecFactory compressionCodecs = new CompressionCodecFactory(conf);
+    public static PcapRecordReader initPcapRecordReader(Path path, long start, long length, TaskAttemptContext context) throws IOException {
+        Configuration conf = context.getConfiguration();
+        FileSystem fs = path.getFileSystem(conf);
+        FSDataInputStream baseStream = fs.open(path);
+        DataInputStream stream = baseStream;
+        CompressionCodecFactory compressionCodecs = new CompressionCodecFactory(conf);
         final CompressionCodec codec = compressionCodecs.getCodec(path);
         if (codec != null)
-        	stream = new DataInputStream(codec.createInputStream(stream));
+            stream = new DataInputStream(codec.createInputStream(stream));
 
-		PcapReader reader = initPcapReader(stream, conf);
-		return new PcapRecordReader(reader, start, length, baseStream, stream, reporter);
-	}
+        PcapReader reader = initPcapReader(stream, conf);
+        return new PcapRecordReader(reader, start, length, baseStream, stream);
+    }
 
-	public static PcapReader initPcapReader(DataInputStream stream, Configuration conf) {
-		try {
-			Class<? extends PcapReader> pcapReaderClass = conf.getClass(READER_CLASS_PROPERTY, PcapReader.class, PcapReader.class);
-			Constructor<? extends PcapReader> pcapReaderConstructor = pcapReaderClass.getConstructor(DataInputStream.class);
-			return pcapReaderConstructor.newInstance(stream);
-		} catch (Exception e) {
-			e.printStackTrace();
-			return null;
-		}
-	}
+    public static PcapReader initPcapReader(DataInputStream stream, Configuration conf) {
+        try {
+            Class<? extends PcapReader> pcapReaderClass = conf.getClass(READER_CLASS_PROPERTY, PcapReader.class, PcapReader.class);
+            Constructor<? extends PcapReader> pcapReaderConstructor = pcapReaderClass.getConstructor(DataInputStream.class);
+            return pcapReaderConstructor.newInstance(stream);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
 
-	/**
-	 * A PCAP can only be read as a whole. There is no way to know where to
-	 * start reading in the middle of the file. It needs to be read from the
-	 * beginning to the end.
-	 * @see http://wiki.wireshark.org/Development/LibpcapFileFormat
-	 */
-	@Override
-	protected boolean isSplitable(FileSystem fs, Path filename) {
-		return false;
-	}
+    protected boolean isSplitable(JobContext context, Path filename) {
+        return false;
+    }
 }

--- a/hadoop-pcap-lib/src/main/java/net/ripe/hadoop/pcap/io/reader/CombinePcapRecordReader.java
+++ b/hadoop-pcap-lib/src/main/java/net/ripe/hadoop/pcap/io/reader/CombinePcapRecordReader.java
@@ -1,49 +1,60 @@
 package net.ripe.hadoop.pcap.io.reader;
 
 import java.io.IOException;
+import java.util.Iterator;
 
 import net.ripe.hadoop.pcap.io.PcapInputFormat;
 
-import org.apache.hadoop.conf.Configuration;
+import net.ripe.hadoop.pcap.packet.Packet;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.ObjectWritable;
-import org.apache.hadoop.mapred.RecordReader;
-import org.apache.hadoop.mapred.Reporter;
-import org.apache.hadoop.mapred.lib.CombineFileSplit;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.lib.input.CombineFileSplit;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.input.FileSplit;
 
 /**
  * Wrapper for CombineFileSplit to RecordReader
  * @author wnagele
  */
-public class CombinePcapRecordReader implements RecordReader<LongWritable, ObjectWritable> {
+public class CombinePcapRecordReader extends RecordReader<LongWritable, ObjectWritable> {
 	private PcapRecordReader recordReader;
+    private Iterator<Packet> pcapReaderIterator;
+    private TaskAttemptContext conf;
+    private FileSplit fileSplit;
+    private LongWritable key;
+    private ObjectWritable value;
+    private Long packetCount = 0L;
 
-	public CombinePcapRecordReader(CombineFileSplit split, Configuration conf, Reporter reporter, Integer index) throws IOException {
+	public CombinePcapRecordReader(CombineFileSplit split, TaskAttemptContext context, Integer index) throws IOException {
 		Path path = split.getPath(index);
 		long start = 0L;
 		long length = split.getLength(index);
-		recordReader = PcapInputFormat.initPcapRecordReader(path, start, length, reporter, conf);
+		recordReader = PcapInputFormat.initPcapRecordReader(path, start, length, context);
 	}
 
-	@Override
-	public boolean next(LongWritable key, ObjectWritable value) throws IOException {
-		return recordReader.next(key, value);
-	}
+    @Override
+    public void initialize(InputSplit inputSplit, TaskAttemptContext taskAttemptContext)
+            throws IOException, InterruptedException {
+        this.fileSplit = (FileSplit) inputSplit;
+        this.conf = taskAttemptContext;
+    }
 
 	@Override
-	public LongWritable createKey() {
-		return recordReader.createKey();
+	public boolean nextKeyValue() throws IOException {
+		return recordReader.nextKeyValue();
 	}
 
-	@Override
-	public ObjectWritable createValue() {
-		return recordReader.createValue();
-	}
+    @Override
+    public LongWritable getCurrentKey() {
+        return key;
+    }
 
 	@Override
-	public long getPos() throws IOException {
-		return recordReader.getPos();
+	public ObjectWritable getCurrentValue() {
+		return value;
 	}
 
 	@Override

--- a/hadoop-pcap-lib/src/test/java/net/ripe/hadoop/pcap/io/reader/PcapIPv6RecordReaderTest.java
+++ b/hadoop-pcap-lib/src/test/java/net/ripe/hadoop/pcap/io/reader/PcapIPv6RecordReaderTest.java
@@ -46,7 +46,7 @@ public class PcapIPv6RecordReaderTest {
 	}
 
 	private void skipToEnd() throws IOException {
-		while (recordReader.next(new LongWritable(), new ObjectWritable()));		
+		while (recordReader.nextKeyValue());
 	}
 
 	@Before
@@ -54,42 +54,11 @@ public class PcapIPv6RecordReaderTest {
 		JobConf config = new JobConf();
 		FileSystem fs = FileSystem.get(config);
 		FSDataInputStream is = fs.open(new Path(TEST_FILE.getParent(), TEST_FILE.getName()));
-		recordReader = new PcapRecordReader(new PcapReader(is), 0L, TEST_FILE.length(), is, is, new TestableReporter());
+		recordReader = new PcapRecordReader(new PcapReader(is), 0L, TEST_FILE.length(), is, is);
 	}
 
 	@After
 	public void shutdown() throws IOException {
 		recordReader.stream.close();
-	}
-
-	private class TestableReporter implements Reporter {
-		@Override
-		public void setStatus(String status) {
-			LOG.debug(status);
-		}
-
-		@Override
-		public Counter getCounter(Enum<?> name) {
-			return null;
-		}
-
-		@Override
-		public Counter getCounter(String group, String name) {
-			return null;
-		}
-
-		@Override
-		public InputSplit getInputSplit() throws UnsupportedOperationException {
-			return null;
-		}
-
-		@Override
-		public void incrCounter(Enum<?> key, long amount) {}
-
-		@Override
-		public void incrCounter(String group, String counter, long amount) {}
-
-		@Override
-		public void progress() {}
 	}
 }

--- a/hadoop-pcap-lib/src/test/java/net/ripe/hadoop/pcap/io/reader/PcapRecordReaderTest.java
+++ b/hadoop-pcap-lib/src/test/java/net/ripe/hadoop/pcap/io/reader/PcapRecordReaderTest.java
@@ -46,7 +46,7 @@ public class PcapRecordReaderTest {
 	}
 
 	private void skipToEnd() throws IOException {
-		while (recordReader.next(new LongWritable(), new ObjectWritable()));		
+		while (recordReader.nextKeyValue());
 	}
 
 	@Before
@@ -54,42 +54,11 @@ public class PcapRecordReaderTest {
 		JobConf config = new JobConf();
 		FileSystem fs = FileSystem.get(config);
 		FSDataInputStream is = fs.open(new Path(TEST_FILE.getParent(), TEST_FILE.getName()));
-		recordReader = new PcapRecordReader(new PcapReader(is), 0L, TEST_FILE.length(), is, is, new TestableReporter());
+		recordReader = new PcapRecordReader(new PcapReader(is), 0L, TEST_FILE.length(), is, is);
 	}
 
 	@After
 	public void shutdown() throws IOException {
 		recordReader.stream.close();
-	}
-
-	private class TestableReporter implements Reporter {
-		@Override
-		public void setStatus(String status) {
-			LOG.debug(status);
-		}
-
-		@Override
-		public Counter getCounter(Enum<?> name) {
-			return null;
-		}
-
-		@Override
-		public Counter getCounter(String group, String name) {
-			return null;
-		}
-
-		@Override
-		public InputSplit getInputSplit() throws UnsupportedOperationException {
-			return null;
-		}
-
-		@Override
-		public void incrCounter(Enum<?> key, long amount) {}
-
-		@Override
-		public void incrCounter(String group, String counter, long amount) {}
-
-		@Override
-		public void progress() {}
 	}
 }

--- a/hadoop-pcap-lib/src/test/java/net/ripe/hadoop/pcap/io/reader/PcapReversedHeaderRecordReaderTest.java
+++ b/hadoop-pcap-lib/src/test/java/net/ripe/hadoop/pcap/io/reader/PcapReversedHeaderRecordReaderTest.java
@@ -46,7 +46,7 @@ public class PcapReversedHeaderRecordReaderTest {
 	}
 
 	private void skipToEnd() throws IOException {
-		while (recordReader.next(new LongWritable(), new ObjectWritable()));		
+		while (recordReader.nextKeyValue());
 	}
 
 	@Before
@@ -54,42 +54,11 @@ public class PcapReversedHeaderRecordReaderTest {
 		JobConf config = new JobConf();
 		FileSystem fs = FileSystem.get(config);
 		FSDataInputStream is = fs.open(new Path(TEST_FILE.getParent(), TEST_FILE.getName()));
-		recordReader = new PcapRecordReader(new PcapReader(is), 0L, TEST_FILE.length(), is, is, new TestableReporter());
+		recordReader = new PcapRecordReader(new PcapReader(is), 0L, TEST_FILE.length(), is, is);
 	}
 
 	@After
 	public void shutdown() throws IOException {
 		recordReader.stream.close();
-	}
-
-	private class TestableReporter implements Reporter {
-		@Override
-		public void setStatus(String status) {
-			LOG.debug(status);
-		}
-
-		@Override
-		public Counter getCounter(Enum<?> name) {
-			return null;
-		}
-
-		@Override
-		public Counter getCounter(String group, String name) {
-			return null;
-		}
-
-		@Override
-		public InputSplit getInputSplit() throws UnsupportedOperationException {
-			return null;
-		}
-
-		@Override
-		public void incrCounter(Enum<?> key, long amount) {}
-
-		@Override
-		public void incrCounter(String group, String counter, long amount) {}
-
-		@Override
-		public void progress() {}
 	}
 }


### PR DESCRIPTION
This PR includes changes updating the InputFormat and RecordReader to use the new MapReduce API (e.g., org.apache.hadoop.mapreduce). The motivation for this change is to make this library usable with Spark Streaming, which does not currently support InputFormats using the old style mapreduce API.

The package builds and tests pass, but there is some warning output through some of the tests.